### PR TITLE
Add AI Daily News - 2026年3月24日

### DIFF
--- a/source/_posts/2026-03-24-ai-daily-news.md
+++ b/source/_posts/2026-03-24-ai-daily-news.md
@@ -1,0 +1,122 @@
+---
+title: 'AI Daily News - 2026年3月24日'
+date: '2026-03-24 08:00:00'
+tags:
+  - AI
+  - News
+  - OpenAI
+  - Anthropic
+  - NVIDIA
+categories:
+  - AI
+---
+
+> 每天 AI 行业重大新闻简报，来源涵盖 OpenAI、Google、Anthropic、NVIDIA 等核心玩家。
+
+## 🚀 大模型 & 产品
+
+### OpenAI
+
+**OpenAI 计划到 2026 年底员工数翻倍**
+OpenAI 计划在 2026 年底将员工数量翻倍，以与 Anthropic 和 Google 竞争。
+📖 [OpenAI to Double Workforce - National Today](https://nationaltoday.com/us/ca/san-francisco/news/2026/03/22/openai-to-double-workforce-by-year-end-to-rival-anthropic-google/)
+
+**OpenAI 预计 2026 年亏损约 140 亿美元**
+OpenAI 预计 2026 年将亏损约 140 亿美元，并可能在 2027 年中期面临资金压力。
+📖 [OpenAI Sora News March 2026 - Instagram](https://www.instagram.com/popular/openai-sora-news-march-2026/)
+
+**SearchGPT 搜索引擎 Beta 测试扩大**
+OpenAI 的 AI 搜索引擎 SearchGPT 现已向所有 Plus 订阅用户开放 Beta 测试。
+📖 [Google OpenAI Anthropic Updates - Medium](https://medium.com/@danielquinteros/google-openai-anthropic-updates-edc94fc6f10e)
+
+---
+
+### Anthropic
+
+**Claude 4 即将发布，或支持 MCP 协议**
+Anthropic 暗示 Claude 4 将在未来几周内发布。新版本可能原生支持 Model Context Protocol (MCP)。
+📖 [Google OpenAI Anthropic Updates - Medium](https://medium.com/@danielquinteros/google-openai-anthropic-updates-edc94fc6f10e)
+
+**Claude 企业版推出私有模型选项**
+Anthropic 发布 Claude Enterprise 重大更新，企业客户现在可以部署完全私有的 Claude 实例。
+📖 [New AI Model Releases March 2026](https://renovateqr.com/blog/ai-model-releases-2026)
+
+---
+
+### Google & DeepMind
+
+**Gemini 2.5 Pro 开放 API，免费额度大幅提升**
+Google 宣布 Gemini 2.5 Pro API 免费额度从每月 50 万 tokens 提升到 200 万 tokens，付费价格下调 40%。
+📖 [New AI Model Releases March 2026](https://renovateqr.com/blog/ai-model-releases-2026)
+
+**Gemini Workspace 新功能上线**
+Google 为 Workspace 推出 Gemini 测试功能：Docs 上下文起草、Sheets 电子表格创建、Slides 演示文稿生成。
+📖 [Google OpenAI Anthropic Updates - Medium](https://medium.com/@danielquinteros/google-openai-anthropic-updates-edc94fc6f10e)
+
+**DeepMind 公布 AlphaFold 3 最新进展**
+DeepMind 展示 AlphaFold 3 最新版本，现在能够预测蛋白质与 DNA、RNA、小分子的复合物结构。
+📖 [New AI Model Releases March 2026](https://renovateqr.com/blog/ai-model-releases-2026)
+
+---
+
+## 💰 融资 & 商业
+
+**Anthropic 获得 4 亿美元 D 轮融资**
+Anthropic 完成 4 亿美元 D 轮融资，估值达 180 亿美元。
+📖 [AI Startups Eating Venture Industry - TechCrunch](https://techcrunch.com/2026/03/20/ai-startups-are-eating-the-venture-industry-and-the-returns-so-far-are-good/)
+
+**Mistral AI 获 6.4 亿美元融资，估值 60 亿美元**
+法国 AI 创业公司 Mistral AI 完成 6.4 亿美元融资，踏入独角兽行列。
+📖 [AI Startups Eating Venture Industry - TechCrunch](https://techcrunch.com/2026/03/20/ai-startups-are-eating-the-venture-industry-and-the-returns-so-far-are-good/)
+
+**AI 初创公司占风投资金 41%**
+根据 Carta 数据，AI 初创公司占据 1280 亿美元风投资金中的 41%。
+📖 [AI Startups Eating Venture Industry - TechCrunch](https://techcrunch.com/2026/03/20/ai-startups-are-eating-the-venture-industry-and-the-returns-so-far-are-good/)
+
+---
+
+## 🖥️ 硬件 & 基础设施
+
+**NVIDIA Blackwell GPU 2026 年出货预期下调**
+JP Morgan 下调 NVIDIA Blackwell GPU 出货预期。2025 年预计出货 520 万片，2026 年降至 180 万片。但新一代 Rubin GPU 预计 2026 年出货 570 万片。
+📖 [NVIDIA Blackwell GPUs - Tweaktown](https://www.tweaktown.com/news/106116/nvidia-expected-to-ship-5-2m-blackwell-gpus-in-2025-1-8m-2026-and-7m-rubin/index.html)
+
+**AMD MI350X 挑战 NVIDIA**
+AMD 发布 Instinct MI350X GPU，声称在 Llama 3.1 405B 推理任务中性能是 H100 的 2.6 倍。
+📖 [New AI Model Releases March 2026](https://renovateqr.com/blog/ai-model-releases-2026)
+
+---
+
+## 🔧 工具 & 开源
+
+**Perplexity 推出 Agent API**
+Perplexity 发布 Agent API，OpenAI 推出 Skills 功能和小型 GPT-5.4 模型。
+📖 [Google OpenAI Anthropic Updates - Medium](https://medium.com/@danielquinteros/google-openai-anthropic-updates-edc94fc6f10e)
+
+**Meta 推迟新 AI 模型 "avocado" 发布**
+因性能问题，Meta 推迟代号为 "avocado" 的新 AI 模型发布。
+📖 [Meta Avocado AI Model Delayed - NYT](https://www.nytimes.com/2026/03/12/technology/meta-avocado-ai-model-delayed.html)
+
+---
+
+## 📊 行业趋势
+
+**AI 代理将成为企业工作流主力**
+行业预测显示，AI 代理将在未来几年显著改变企业工作流程。
+
+**Anthropic Institute 与供应链风险标签争议**
+Anthropic 的 Institute 推出引发讨论，供应链风险标签问题成为关注焦点。
+📖 [Google OpenAI Anthropic Updates - Medium](https://medium.com/@danielquinteros/google-openai-anthropic-updates-edc94fc6f10e)
+
+---
+
+## 📰 相关报道
+
+- **NYT: AI Agents 的应用** (March 19, 2026)
+- **NYT: 年轻程序员与 AI 焦虑** (March 19, 2026)
+- **NYT: 白宫 AI 政策** (March 20, 2026)
+- **NYT: 五角大楼与 Anthropic 合同争议** (March 17, 2026)
+
+---
+
+> 📌 明天见！


### PR DESCRIPTION
## 内容

- 2026年3月24日 AI 行业新闻汇总
- 包含 OpenAI、Anthropic、Google、NVIDIA 等最新动态
- 所有新闻均附有来源链接